### PR TITLE
Quantity#initialize should fail fast on invalid input

### DIFF
--- a/lib/quantify/quantity.rb
+++ b/lib/quantify/quantity.rb
@@ -124,12 +124,17 @@ module Quantify
     # unit
     def initialize(value, unit = 'unity')
       if value
-        @value = value.to_f
+        @value = Float(value)
       else
         @value = nil
       end
       if unit
         @unit = Unit.for(unit)
+        #TODO: Actually this is a bad hack. Unit should raise an error in the first place
+        #instead of returning nil. But I did not manage to quickly solve this issue as
+        #the specs seem to explode as soon as we swtich from Unit.for(...) to Unit.parse
+        #(Unit.parse() should raise errors but seems to have problems on its own)
+        raise ArgumentError, "Unit '#{unit}' is not a valid unit" if @unit.nil? && unit != nil
       else
         @unit = Unit.for('unity')
       end

--- a/spec/quantity_spec.rb
+++ b/spec/quantity_spec.rb
@@ -12,6 +12,14 @@ describe Quantity do
     specify { Quantity.new(nil).should eq(Quantity.new(nil,'unity')) }
   end
 
+  it "should fail fast on invalid value input" do
+    expect{ Quantity.new('invalid', 'kg') }.to raise_error ArgumentError
+  end
+
+  it "should fail fast on invalid unit input" do
+    expect{ Quantity.new(1, 'invalid unit') }.to raise_error ArgumentError
+  end
+
   it "should create a valid instance with nil values" do
     quantity = Quantity.new nil, nil
     quantity.value.should be_nil


### PR DESCRIPTION
Silencing value or unit errors is not the best solution. Better let users of the API deal with the errors. For the [quantify_mongoid](https://github.com/cblock/quantify_mongoid) gem I need these errors to be raised so that I can establish proper ActiveModel Validation errors for the invalid form field inputs.  
