### PR TITLE
Core extension for Numeric should not fail with an InvalidUnitError

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Quantity.new(nil, nil)              #=> <Quantify::Quantity:0xb7332bbc ... >
 _.value                             #=> nil
 _.unit                              #=> <Quantify::Unit::Base:0x007ff622bd9320 ...>
 _.unit.name                         #=> "unity" #== 'unitless' unit
+
+Quantity.new(100)                   #=> <Quantify::Quantity:0xb7332bbc ... >
+_.value                             #=> 100.0
+_.unit                              #=> <Quantify::Unit::Base:0x007ff622bd9320 ...>
+_.unit.name                         #=> "unity" #== 'unitless' unit
+_.to_si.value                       #=> 100.0 #identity transformation for unitless quantities
 ```
     
 General introduction

--- a/lib/quantify/core_extensions/numeric.rb
+++ b/lib/quantify/core_extensions/numeric.rb
@@ -9,11 +9,10 @@ class Numeric
   #   1000.t         is equivalent to Quantity. new 1000, :t
   #
   def method_missing(method, *args, &block)
-    if (method == :to_str || method == :to_ary)
-      super
-    elsif unit = Unit.for(method.to_s)
-      Quantify::Quantity.new self, unit
-    else
+    return super if (method == :to_str || method == :to_ary)
+    begin
+      Quantify::Quantity.new self, method.to_s
+    rescue Exception
       super
     end
   end

--- a/lib/quantify/quantity.rb
+++ b/lib/quantify/quantity.rb
@@ -214,6 +214,8 @@ module Quantify
     def to_si
       if @unit.is_compound_unit?
         Quantity.new(@value,@unit).convert_compound_unit_to_si!
+      elsif @unit.is_dimensionless?
+        return self
       else
         self.to(@unit.si_unit)
       end

--- a/spec/quantity_spec.rb
+++ b/spec/quantity_spec.rb
@@ -517,6 +517,11 @@ describe Quantity do
     speed.to_si.to_s(:name).should == "44.704 metres per second"
   end
 
+  it "should convert dimensionless units to SI identity operation" do
+    unity_quantity = Quantity.new 100
+    unity_quantity.to_si.should eq(unity_quantity)
+  end
+
   it "should convert compound units to SI correctly" do
     speed = Quantity.new 100, (Unit.km/Unit.h)
     speed.to_si.value.should be_within(0.0000000000001).of(27.7777777777778)

--- a/spec/unit_spec.rb
+++ b/spec/unit_spec.rb
@@ -483,7 +483,11 @@ describe Unit do
     it "should recognise compound unit with multiple word pluralized name" do
       Unit.centimetres_of_mercury_per_hour_US_bushels.symbol.should eql "cmHg/h bu (Imp)"
     end
-    
+
+    it "should throw a NoMethodError when trying to inflect unit from method missing" do
+      expect { 12.ago }.to raise_error NoMethodError
+    end
+
     describe "parsing unit string" do
       
       it "should parse string into correct single unit" do


### PR DESCRIPTION
Instead, it should handle this error and over processing to super
