### PR TITLE
quantity.value= and quantity.unit= now also fail fast on invalid inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ _.to_s                              #=> "0.68 kg"
 Unit.ratio(:kg, :ton)               #=> <Quantify::Quantity:0xb7332bbc ... >
 _.to_s                              #=> "1016.047 kilograms per long ton"
 
-Quantity.new(nil, nil)              #=> <Quantify::Quantity:0xb7332bbc ... >
+Quantity.new(nil)                   #=> <Quantify::Quantity:0xb7332bbc ... >
 _.value                             #=> nil
 _.unit                              #=> <Quantify::Unit::Base:0x007ff622bd9320 ...>
 _.unit.name                         #=> "unity" #== 'unitless' unit
@@ -48,7 +48,10 @@ Quantity.new(100)                   #=> <Quantify::Quantity:0xb7332bbc ... >
 _.value = 'invalid value'           #=> raises ArgumentError
 
 Quantity.new(100)                   #=> <Quantify::Quantity:0xb7332bbc ... >
-_.unit = 'invalid unit'             #=> raises InvalidUnitError
+_.value = nil                       #=> nil
+
+Quantity.new(100)                   #=> <Quantify::Quantity:0xb7332bbc ... >
+_.unit = nil                        #=> "unity" #== 'unitless' unit
 ```
     
 General introduction

--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ _.value                             #=> 100.0
 _.unit                              #=> <Quantify::Unit::Base:0x007ff622bd9320 ...>
 _.unit.name                         #=> "unity" #== 'unitless' unit
 _.to_si.value                       #=> 100.0 #identity transformation for unitless quantities
+
+Quantity.new(100)                   #=> <Quantify::Quantity:0xb7332bbc ... >
+_.value = 'invalid value'           #=> raises ArgumentError
+
+Quantity.new(100)                   #=> <Quantify::Quantity:0xb7332bbc ... >
+_.unit = 'invalid unit'             #=> raises InvalidUnitError
 ```
     
 General introduction

--- a/lib/quantify/quantity.rb
+++ b/lib/quantify/quantity.rb
@@ -121,7 +121,17 @@ module Quantify
     
     public
 
-    attr_accessor :value, :unit
+    attr_reader :value, :unit
+
+    # Float(...) ensures an error is raised if value is not representable as number
+    def value=(value)
+      @value = Float(value)
+    end
+
+    # Unit.for(...) ensures an error is rasied if unit is not a valid unit
+    def unit=(unit)
+      @unit = Unit.for(unit)
+    end
 
     # Initialize a new Quantity object. Two arguments are required: a value and
     # a unit. The unit can be a an instance of Unit::Base or the label, name, symbol or

--- a/lib/quantify/quantity.rb
+++ b/lib/quantify/quantity.rb
@@ -125,12 +125,20 @@ module Quantify
 
     # Float(...) ensures an error is raised if value is not representable as number
     def value=(value)
-      @value = Float(value)
+      if value.nil?
+        @value = nil
+      else
+        @value = Float(value)
+      end
     end
 
     # Unit.for(...) ensures an error is rasied if unit is not a valid unit
     def unit=(unit)
-      @unit = Unit.for(unit)
+      if unit.nil?
+        @unit = Unit.for(:unity)
+      else
+        @unit = Unit.for(unit)
+      end
     end
 
     # Initialize a new Quantity object. Two arguments are required: a value and

--- a/spec/quantity_spec.rb
+++ b/spec/quantity_spec.rb
@@ -16,9 +16,20 @@ describe Quantity do
     expect{ Quantity.new('invalid', 'kg') }.to raise_error ArgumentError
   end
 
+  it "should fail fast on invalid value assignment" do
+    quantity = Quantity.new(10, 'kg')
+    expect{ quantity.value = 'invalid' }.to raise_error ArgumentError
+  end
+
   it "should fail fast on invalid unit input" do
     expect{ Quantity.new(1, 'invalid unit') }.to raise_error Quantify::Exceptions::InvalidUnitError
   end
+
+  it "should fail fast on invalid unit assignment" do
+    quantity = Quantity.new(10, 'kg')
+    expect{ quantity.unit = 'invalid unit' }.to raise_error Quantify::Exceptions::InvalidUnitError
+  end
+
 
   it "should create a valid instance with nil values" do
     quantity = Quantity.new nil, nil

--- a/spec/quantity_spec.rb
+++ b/spec/quantity_spec.rb
@@ -32,7 +32,7 @@ describe Quantity do
 
 
   it "should create a valid instance with nil values" do
-    quantity = Quantity.new nil, nil
+    quantity = Quantity.new nil
     quantity.value.should be_nil
     quantity.unit.should == (Unit.for('unity'))
   end
@@ -42,6 +42,20 @@ describe Quantity do
     quantity.value.should eql 100.0
     quantity.unit.is_dimensionless?.should be_true
     quantity.to_s.should eql "100.0"
+  end
+
+  it "sets value to nil" do
+    quantity = Quantity.new 100, 'kg'
+    quantity.value.should eq(100)
+    quantity.value = nil
+    quantity.value.should be_nil
+  end
+
+  it "sets unit to unity when assigned nil" do
+    quantity = Quantity.new 100, 'kg'
+    quantity.unit.should eq(Unit.for('kg'))
+    quantity.unit = nil
+    quantity.unit.should eq(Unit.for(:unity))
   end
 
   it "should create a valid instance with standard create and unit name" do


### PR DESCRIPTION
This is to make their behaviour consistent with the behaviour of the constructor.

...just got caught by this one... :)
