### PR TITLE
#to_si for nil quantities and errors when comparing unit with nil

### DIFF
--- a/lib/quantify/quantity.rb
+++ b/lib/quantify/quantity.rb
@@ -234,6 +234,9 @@ module Quantify
         Quantity.new(@value,@unit).convert_compound_unit_to_si!
       elsif @unit.is_dimensionless?
         return self
+      elsif @value.nil?
+        @unit = @unit.si_unit
+        return self
       else
         self.to(@unit.si_unit)
       end

--- a/lib/quantify/unit/base_unit.rb
+++ b/lib/quantify/unit/base_unit.rb
@@ -389,6 +389,7 @@ module Quantify
       #                                      #=> true
       #
       def is_equivalent_to?(other)
+        return false if other.nil?
         [:dimensions,:factor,:scaling].all? do |attr|
           self.send(attr) == other.send(attr)
         end

--- a/spec/quantity_spec.rb
+++ b/spec/quantity_spec.rb
@@ -547,6 +547,11 @@ describe Quantity do
     unity_quantity.to_si.should eq(unity_quantity)
   end
 
+  it "should convert quantities with nil values to SI" do
+    nil_quantity = Quantity.new nil, 'mV'
+    nil_quantity.to_si.should eq(Quantity.new(nil, 'V'))
+  end
+
   it "should convert compound units to SI correctly" do
     speed = Quantity.new 100, (Unit.km/Unit.h)
     speed.to_si.value.should be_within(0.0000000000001).of(27.7777777777778)

--- a/spec/unit_spec.rb
+++ b/spec/unit_spec.rb
@@ -1011,6 +1011,11 @@ describe Unit do
       (unit_1.is_equivalent_to? unit_2).should_not == true
     end
 
+    it "should compare to nil" do
+      unit = Unit.yard
+      (unit.is_equivalent_to? nil).should be_false
+    end
+
     it "should recognise known units from compound units based on dimensions and factor" do
       unit = Unit.kg*Unit.m*Unit.m/Unit.s/Unit.s
       unit.equivalent_known_unit.name.should == 'joule'


### PR DESCRIPTION
Example cases:
- `Quantity.new(nil, 'mm').to_si` should not fail but return a Quantity with value nil and unit set to si_unit 
- `Quantity.new(10,'km') == nil` should not fail but return `false`
